### PR TITLE
fix typo to make URL work

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Nordufer 20
 13353 Berlin  
   
 ---
-**You can find an english version of the readme [here](readme_en.md)**  
+**You can find an english version of the readme [here](Readme_en.md)**  
 
 Robert Koch-Institut (2023): SARS-CoV-2-Sequenzdaten aus Deutschland, Berlin: Zenodo. [DOI: 10.5281/zenodo.7505087](https://doi.org/10.5281/zenodo.7505087)  
  


### PR DESCRIPTION
The GitHub URL seems case sensitive, so I changed the currently not working link in the `Readme.md` from 

https://github.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/blob/master/readme_en.md

to

https://github.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/blob/master/Readme_en.md